### PR TITLE
Fixed SimpleAL PUBLIC_HEADER_FOLDERS_PATH

### DIFF
--- a/SimpleAL.xcodeproj/project.pbxproj
+++ b/SimpleAL.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 				GCC_PREFIX_HEADER = "Other Sources/SimpleAL-Prefix.pch";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = SimpleAL;
+				PUBLIC_HEADERS_FOLDER_PATH = ../../Headers/SimpleAL;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -416,6 +417,7 @@
 				GCC_PREFIX_HEADER = "Other Sources/SimpleAL-Prefix.pch";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = SimpleAL;
+				PUBLIC_HEADERS_FOLDER_PATH = ../../Headers/SimpleAL;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;


### PR DESCRIPTION
this fix puts SimpleAL's public headers in a place Xcode can find them while compiling the app
