### PR TITLE
Scripts for migrating to NSLayoutAnchor

### DIFF
--- a/tools/al2layoutanchor_objc.rb
+++ b/tools/al2layoutanchor_objc.rb
@@ -1,0 +1,83 @@
+#!/usr/bin/env ruby
+
+USAGE = <<END
+usage: #{$0} filename ...
+
+This script converts "basic" usage of SimpleAL to NSLayoutAnchor. It matches
+lines of the form:
+    
+  [<SimpleALViewProperty> <ViewProperty method>:<SimpleALViewProperty> ...]
+
+and converts it to equivalent NSLayoutAnchor syntax:
+
+  [<NSLayoutAnchor> <NSLayoutAnchor method>:<NSLayoutAnchor> ...]
+
+For example:
+  [imageView.al_height equalToViewProperty:imageView.al_width]
+becomes:
+  [imageView.heightAnchor constraintEqualToAnchor:imageView.widthAnchor]
+END
+
+ANCHOR_MAP = {
+  "al_top"      => "topAnchor",
+  "al_baseline" => "lastBaselineAnchor",
+  "al_bottom"   => "bottomAnchor",
+  "al_centerX"  => "centerXAnchor",
+  "al_centerY"  => "centerYAnchor",
+  "al_height"   => "heightAnchor",
+  "al_leading"  => "leadingAnchor",
+  "al_left"     => "leftAnchor",
+  "al_right"    => "rightAnchor",
+  "al_trailing" => "trailingAnchor",
+  "al_width"    => "widthAnchor"
+}
+
+# Returns the NSLayoutAnchor property name equivalent to SimpleAL view
+# properties `symbol`.
+def anchor(symbol)
+  ANCHOR_MAP[symbol]
+end
+
+# Returns `str` with all SimpleAL view properties converted to NSLayoutAnchor
+# property names.
+def anchors(str)
+  str.gsub(/[a-zA-Z_][a-zA-Z0-9_0]*/) { |token| anchor(token) || token }
+end
+
+ARG = /([^ \]]+)/
+AL  = /(Anchor)/
+
+# Maps regexps matching a SimpleALViewProperty method call to the equivalent
+# NSLayoutAnchor method call.
+CALL_MAP = {
+  /#{AL} equalToViewProperty:#{ARG}/ =>
+    ->(m) { "#{$1} constraintEqualToAnchor:#{$2}" },
+  /#{AL} lessThanOrEqualToViewProperty:#{ARG}/ =>
+    ->(m) { "#{$1} constraintLessThanOrEqualToAnchor:#{$2}" },
+  /#{AL} greaterThanOrEqualToViewProperty:#{ARG}/ =>
+    ->(m) { "#{$1} constraintGreaterThanOrEqualToAnchor:#{$2}" },
+  /#{AL} equalToValue:#{ARG}/ =>
+    ->(m) { "#{$1} constraintEqualToConstant:#{$2}" },
+  /#{AL} lessThanOrEqualToValue:#{ARG}/ =>
+    ->(m) { "#{$1} constraintLessThanOrEqualToConstant:#{$2}" },
+  /#{AL} greaterThanOrEqualToValue:#{ARG}/ =>
+    ->(m) { "#{$1} constraintGreaterThanOrEqualToConstant:#{$2}" },
+}
+
+abort USAGE if ARGV.empty?
+ARGV.each do |filename|
+  code = File.readlines filename
+  file_changed = false
+  code.each do |line|
+    line_changed = ANCHOR_MAP.map { |match, subst| line.gsub!(match, subst) }
+                             .any? { |s| s }
+    line_changed = CALL_MAP.map { |match, block| line.gsub!(match, &block) }
+                           .any? { |s| s } || line_changed
+    file_changed = file_changed || line_changed
+  end
+  
+  if file_changed
+    File.write filename, code.join
+    puts "Converted #{filename}" 
+  end
+end

--- a/tools/al2layoutanchor_swift.rb
+++ b/tools/al2layoutanchor_swift.rb
@@ -1,0 +1,98 @@
+#!/usr/bin/env ruby
+
+USAGE = <<END
+usage: #{$0} filename ...
+
+This script converts "basic" usage of SimpleAL to NSLayoutAnchor. It matches
+lines of the form:
+    
+  <view>.<SimpleAL property>.<SimpleAL constraint factory>(<constraint type>: <constraint value>)
+
+and converts it to equivalent NSLayoutAnchor syntax:
+
+  <view>.<anchor>.constraint(<NSLayoutAnchor constraint type>: <constraint value>)
+
+For example:
+  imageView.al_height.equal(to: imageView.al_width)
+becomes:
+  imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor)
+END
+
+ANCHOR_MAP = {
+  "al_top"      => "topAnchor",
+  "al_baseline" => "lastBaselineAnchor",
+  "al_bottom"   => "bottomAnchor",
+  "al_centerX"  => "centerXAnchor",
+  "al_centerY"  => "centerYAnchor",
+  "al_height"   => "heightAnchor",
+  "al_leading"  => "leadingAnchor",
+  "al_left"     => "leftAnchor",
+  "al_right"    => "rightAnchor",
+  "al_trailing" => "trailingAnchor",
+  "al_width"    => "widthAnchor"
+}
+
+# Returns the NSLayoutAnchor property name equivalent to SimpleAL view
+# properties `symbol`.
+def anchor(symbol)
+  ANCHOR_MAP[symbol]
+end
+
+# Returns `str` with all SimpleAL view properties converted to NSLayoutAnchor
+# property names.
+def anchors(str)
+  str.gsub(/[a-zA-Z_][a-zA-Z0-9_0]*/) { |token| anchor(token) || token }
+end
+
+ARG = /([^,\)]+)/
+AL  = /(Anchor)/
+
+# Maps regexps matching a SimpleALViewProperty method call to the equivalent
+# NSLayoutAnchor method call.
+CALL_MAP = {
+  /#{AL}\.equal\(to: #{ARG}\)/ => 
+    ->(m) { "#{$1}.constraint(equalTo: #{$2})" },
+  /#{AL}\.equal\(to: #{ARG}, constant: #{ARG}\)/ =>
+    ->(m) { "#{$1}.constraint(equalTo: #{$2}, constant: #{$3})" },
+  /#{AL}\.equal\(to: #{ARG}, multiplier: #{ARG}, constant: #{ARG}\)/ =>
+    ->(m) { "#{$1}.constraint(equalTo: #{$2}, multiplier: #{$3}, constant: #{$4})" },
+
+  /#{AL}\.greaterThanOrEqual\(to: #{ARG}\)/ =>
+    ->(m) { "#{$1}.constraint(greaterThanOrEqualTo: #{$2})" },
+  /#{AL}\.greaterThanOrEqual\(to: #{ARG}, constant: #{ARG}\)/ =>
+    ->(m) { "#{$1}.constraint(greaterThanOrEqualTo: #{$2}, constant: #{$3})" },
+  /#{AL}\.greaterThanOrEqual\(to: #{ARG}, multiplier: #{ARG}, constant: #{ARG}\)/ =>
+    ->(m) { "#{$1}.constraint(greaterThanOrEqualTo: #{$2}, multiplier: #{$3}, constant: #{$4})" },
+
+  /#{AL}\.lessThanOrEqual\(to: #{ARG}\)/ =>
+    ->(m) { "#{$1}.constraint(lessThanOrEqualTo: #{$2})" },
+  /#{AL}\.lessThanOrEqual\(to: #{ARG}, constant: #{ARG}\)/ =>
+    ->(m) { "#{$1}.constraint(lessThanOrEqualTo: #{$2}, constant: #{$3})" },
+  /#{AL}\.lessThanOrEqual\(to: #{ARG}, multiplier: #{ARG}, constant: #{ARG}\)/ =>
+    ->(m) { "#{$1}.constraint(lessThanOrEqualTo: #{$2}, multiplier: #{$3}, constant: #{$4})" },
+
+  /#{AL}\.equal\(toValue: #{ARG}\)/ =>
+    ->(m) { "#{$1}.constraint(equalToConstant: #{$2})" },
+  /#{AL}\.lessThanOrEqual\(toValue: #{ARG}\)/ =>
+    ->(m) { "#{$1}.constraint(lessThanOrEqualToConstant: #{$2})" },
+  /#{AL}\.greaterThanOrEqual\(toValue: #{ARG}\)/ =>
+    ->(m) { "#{$1}.constraint(greaterThanOrEqualToConstant: #{$2})" },
+}
+
+abort USAGE if ARGV.empty?
+ARGV.each do |filename|
+  code = File.readlines filename
+  file_changed = false
+  code.each do |line|
+    line_changed = ANCHOR_MAP.map { |match, subst| line.gsub!(match, subst) }
+                             .any? { |s| s }
+    line_changed = CALL_MAP.map { |match, block| line.gsub!(match, &block) }
+                           .any? { |s| s } || line_changed
+    file_changed = file_changed || line_changed
+  end
+  
+  if file_changed
+    File.write filename, code.join
+    puts "Converted #{filename}" 
+  end
+end


### PR DESCRIPTION
[NSLayoutAnchor][1] (available in iOS 9.0) duplicates most functionality of SimpleAL and has a roughly 1-to-1 syntax correspondance. I've been working on replacing SimpleAL with NSLayoutAnchor across a few projects. To speed up my work, I wrote scripts to map the `UIView` category properties to equivalent anchor properties, and replace `SimpleALViewProperty` methods with the equivalent `NSLayoutAnchor` methods. For example, `al2layoutanchor_swift.rb` replaces

```swift
view1.al_left.equal(to: view2.al_left, constant: 0)
```
with
```swift
view1.leftAnchor.constraint(equalTo: view2.leftAnchor, constant: 0)
```

 These migrators would be useful to anyone else interested in switching from SimpleAL to NSLayoutAnchor.

I don't know if it'd be useful to have these scripts in the repo, but I couldn't think of a better place to keep track of them.

[1]: https://developer.apple.com/reference/uikit/nslayoutanchor